### PR TITLE
Add helpers for client to connect to server, refactored database helpers

### DIFF
--- a/client/src/server-helpers.js
+++ b/client/src/server-helpers.js
@@ -1,0 +1,91 @@
+import $ from ('jquery');
+
+const baseUrl = 'http://localhost:3000/';
+
+export const createNewUser = (username, password) => {
+  $.ajax({
+    "url": baseUrl + "users/",
+    "method": "POST",
+    "headers": {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    "data": {
+      "password": password,
+      "username": username
+    }
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+};
+
+// Obj example: {"password": "potato", "wins": 87}
+// Keys must be fields in users table
+export const updateUser = (userId, obj) => {
+  $.ajax({
+    "url": baseUrl + "users/" + userId,
+    "method": "POST",
+    "headers": {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    "data": obj
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+};
+
+export const getUser = userId => {
+  $.ajax({
+    "url": baseUrl + "users/" + userId,
+    "method": "GET"
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+};
+
+export const createNewGame = (user1Id, user2Id) => {
+  $.ajax({
+    "url": baseUrl + "games/",
+    "method": "POST",
+    "headers": {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    "data": {
+      "user1Id": user1Id,
+      "user2Id": user2Id
+    }
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+};
+
+// Keys must be fields in games table
+// ATM, values in db will be totally overwritten by your obj values,
+// rather than concatenated.
+export const updateGame = (gameId, obj) => {
+  $.ajax({
+    "url": baseUrl + "games/" + gameId,
+    "method": "POST",
+    "headers": {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    "data": obj 
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+};
+
+export const getGame = gameId => {
+  $.ajax({
+    "url": baseUrl + "games/" + gameId,
+    "method": "GET"
+  }).done(response => {
+    // do something with response...
+    console.log(response);
+  });
+}; 
+

--- a/database/database-helpers.js
+++ b/database/database-helpers.js
@@ -2,18 +2,10 @@ const sequelize = require('sequelize');
 const connection = require('../database/index.js');
 
 
-// Turn a req.body into a string to use in sql UPDATE query
-const makeUpdateString = (obj) => {
-  let keyValArr = [];
-  for (let key in obj) {
-    keyValArr.push(`${key} = ${obj[key]}`);
-  }
-  return keyValArr.join(', ');
-}
-
-// Working!
-const createNewPlayer = (userName, password, callback) => {
-  connection.query( `INSERT into users (username, password) Values ('${userName}', '${password}')`, (err, results, fields) => {
+// Updated syntax to simplify code and use built-in escaping functionality,
+// preventing SQL injection attacks
+const createNewPlayer = (obj, callback) => {
+  connection.query( `INSERT into users SET ?`, obj, (err, results, fields) => {
     if (err) {
       callback(err, null);
     } else {
@@ -35,22 +27,20 @@ const selectPlayersGames = (userId, callback) => {
   });
 };
 
-// Working!
 const getGame = (gameId, callback) => {
   connection.query(`SELECT * FROM games WHERE id = ${gameId}`, (err, results, fields) => {
     if (err) {
       callback(err, null); 
     } else {
       callback(null, results);
-    } 
+    }
   });
-};
+}; 
 
-// Working!
-const createNewGame = (user1Id, user2Id, callback) => {
+const createNewGame = (obj, callback) => {
   connection.query(
     `INSERT into games (player1ID, player1Placement, player1Hits, player1Misses, player2ID, player2Placement, player2Hits, player2Misses, result) Values (
-    ${user1Id}, '[]', '[]', '[]', ${user2Id}, '[]', '[]', '[]', null)`, (err, results, fields) => {
+    ${obj.user1Id}, '[]', '[]', '[]', ${obj.user2Id}, '[]', '[]', '[]', null)`, (err, results, fields) => {
       //creates a new game between user1Id, and user2Id. Starts with empty tuples.
       if (err) {
         callback(err, null); 
@@ -60,10 +50,10 @@ const createNewGame = (user1Id, user2Id, callback) => {
     });
 };
 
-
-// Working!
+// Updated syntax to simplify code and use built-in escaping functionality,
+// preventing SQL injection attacks
 const updateGame = (gameId, obj, callback) => {
-  connection.query(`UPDATE games SET ${makeUpdateString(obj)} WHERE id = ${gameId}`, (err, results, fields) => {
+  connection.query(`UPDATE games SET ? WHERE id = ${gameId}`, obj, (err, results, fields) => {
     if(err) {
      callback(err, null); 
     } else {
@@ -72,9 +62,10 @@ const updateGame = (gameId, obj, callback) => {
   });
 };
 
-// Working!
+// Updated syntax to simplify code and use built-in escaping functionality,
+// preventing SQL injection attacks
 const updateUser = (userId, obj, callback) => {
-  connection.query(`UPDATE users SET ${makeUpdateString(obj)} WHERE id = ${userId}`, (err, results, fields) => {
+  connection.query(`UPDATE users SET ? WHERE id = ${userId}`, obj, (err, results, fields) => {
     if(err) {
      callback(err, null); 
     } else {
@@ -83,7 +74,6 @@ const updateUser = (userId, obj, callback) => {
   });
 };
 
-// Working!
 const getUser = (userId, callback) => {
   connection.query(`SELECT * FROM users WHERE id = ${userId}`, (err, results) => {
     if (err) {
@@ -140,6 +130,7 @@ const getUser = (userId, callback) => {
 
 module.exports.selectPlayersGames = selectPlayersGames;
 module.exports.createNewGame = createNewGame;
+module.exports.createNewPlayer = createNewPlayer;
 //module.exports.breadPlacement = breadPlacement;
 //module.exports.guessLocation = guessLocation;
 //module.exports.playerLevelUp = playerLevelUp;

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,11 @@ const app = express();
 app.use(express.static(__dirname + '/../client/'));
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*"); // Using to make testing easier
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
 
 app.get('/', (req, res) => {
   res.send('index.html');
@@ -20,13 +25,14 @@ app.post('/login', (req, res) => {
   // log user in
 });
 
-// This endpoint only for starting new games
+// This endpoint only for starting new games.
+// Requires req.body to have user1ID and user2ID properties.
 app.post('/games', (req, res) => {
-  db.createNewGame(req.body.user1ID, req.body.user2ID, (err, results) => {
+  db.createNewGame(req.body, (err, results) => {
     if (err) { 
       console.error(err); 
     } else {
-      console.log('Created new game: ', results);
+      console.log('Created new game: ', JSON.stringify(results));
       res.send(results);
     }
   }); 
@@ -38,9 +44,8 @@ app.get('/games/:gameId', (req, res) => {
     if (err) { 
       console.error(err); 
     } else {
-      console.log('Retrieved game info: ', results[0]);
+      console.log('Retrieved game info: ', JSON.stringify(results[0]));
       res.send(clientHelpers.buildStateForClient(results[0]));
-      //res.send(results);  
     }    
   });
 });
@@ -51,21 +56,22 @@ app.post('/games/:gameId', (req, res) => {
     if (err) { 
       console.error(err); 
     } else {
-      console.log('Updated game: ', results);
+      console.log('Updated game: ', JSON.stringify(results));
       res.send(results);
     }
   });
 });
 
-// This endpoint only for creating new users
+// This endpoint only for creating new users.
+// Requires req.body to have username and password properties.
 app.post('/users', (req, res) => {
-  db.createNewPlayer(req.body.userName, req.body.password, (err, results) => {
+  db.createNewPlayer(req.body, (err, results) => {
     if (err) { 
       console.error(err); 
     } else {
-      //console.log('Created new user: ', results);
+      console.log('Created new user: ', JSON.stringify(results));
       res.send(results);
-    }
+    } 
   }); 
 });
 
@@ -75,7 +81,7 @@ app.get('/users/:userId', (req, res) => {
     if (err) { 
       console.error(err); 
     } else {
-      console.log('Retrieved user: ', results);
+      console.log('Retrieved user: ', JSON.stringify(results));
       res.send(results);
     }
   });
@@ -87,7 +93,7 @@ app.post('/users/:userId', (req, res) => {
     if (err) { 
       console.error(err); 
     } else {
-      console.log('Updated user: ', results);
+      console.log('Updated user: ', JSON.stringify(results));
       res.send(results);
     }
   });


### PR DESCRIPTION
I changed the way our SQL queries are constructed. This protects from SQL injection attacks thanks to the mysql package's built-in escaping (kicks in with the new syntax). It is slightly less readable, unfortunately.

Added a server-helpers file for the client side to connect to the server. The functions should be self-explanatory. They're written with $.ajax and tested using the chrome console, but if you want to refactor with axios or something else, the recipe should be clear.

To do the $.ajax testing I needed to add CORS headers to the server code. In production this should be changed.

